### PR TITLE
Use AWS_REGION which is built-in to AWS SDK

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,3 @@
+AWS_REGION=us-east-1
+S3_BUCKET_NAME=fieldpapers
+API_BASE_URL=http://fieldpapers.org/

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN \
 ENV HOME /app
 ENV PORT 8080
 ENV NODE_ENV production
+ENV AWS_REGION us-east-1
 WORKDIR /app
 
 ADD package.json /app/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This is intended to be run from a Docker image. `-v $(pwd):/app` facilitates
 local development, `--env-file` propagates environment variables into the
-container.
+container.  See `.env.sample` for sample `.env` file.
 
 ```bash
 docker run --rm \

--- a/lib/shell.js
+++ b/lib/shell.js
@@ -9,10 +9,6 @@ const AWS = require("aws-sdk"),
 
 const spawn = require("./spawn");
 
-AWS.config.update({
-  region: process.env.AWS_DEFAULT_REGION || "us-east-1"
-});
-
 const S3 = new AWS.S3();
 
 module.exports = function shell(cmd, args, spawnOptions, s3Options, _callback) {

--- a/lib/tasks/convert_pdf_to_geotiff.js
+++ b/lib/tasks/convert_pdf_to_geotiff.js
@@ -14,10 +14,6 @@ const spawn = require("../spawn");
 
 const S3_BUCKET_NAME = env.require("S3_BUCKET_NAME");
 
-AWS.config.update({
-  region: process.env.AWS_DEFAULT_REGION || "us-east-1"
-});
-
 const S3 = new AWS.S3();
 
 const spawnAndCaptureStdErr = function spawnAndCaptureStdErr() {

--- a/lib/tasks/fetch_snapshot_metadata.js
+++ b/lib/tasks/fetch_snapshot_metadata.js
@@ -14,10 +14,6 @@ const async = require("async"),
 
 const sentry = new raven.Client();
 
-AWS.config.update({
-  region: process.env.AWS_DEFAULT_REGION || "us-east-1"
-});
-
 const S3 = new AWS.S3();
 
 const createImageStream = function createImageStream(imageUrl) {

--- a/lib/tasks/process_snapshot.js
+++ b/lib/tasks/process_snapshot.js
@@ -19,10 +19,6 @@ const sentry = new raven.Client();
 
 const S3_BUCKET_NAME = env.require("S3_BUCKET_NAME");
 
-AWS.config.update({
-  region: process.env.AWS_DEFAULT_REGION || "us-east-1"
-});
-
 const S3 = new AWS.S3();
 
 const download = function download(imageUrl, filename, callback) {


### PR DESCRIPTION
In AWS SDKs, it seems fairly consistent that `AWS_DEFAULT_REGION` is use for CLI, and `AWS_REGION` is used for libraries.  The JS SDK uses `AWS_REGION`.  This patch replaces/removes all uses of `AWS_DEFAULT_REGION` (in preference of `AWS_REGION`).  This is more consistent with the rest of Field Papers as well.

Also added a `.env.sample`.
