### PR TITLE
Configurable local persistence

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 * Support multiple S3 regions
 * Use `AWS_REGION` instead of `AWS_DEFAULT_REGION`
 * Upgrade Node to v5.x
+* Support local file persistence
 
 ## v0.9.0 - 6/19/15
 

--- a/README.md
+++ b/README.md
@@ -13,3 +13,16 @@ docker run --rm \
   --env-file .env \
   fieldpapers/tasks
 ```
+
+## Environment variables
+
+* `AWS_REGION` - AWS region. Required if using S3.
+* `S3_BUCKET_NAME` - S3 bucket name. Required if using S3.
+* `API_BASE_URL` - Base Field Papers API URL (used when generating QR codes and
+  titles). Defaults to `http://fieldpapers.org/`.
+* `PERSIST` - File persistence. Can be `local` or `s3`. Defaults to `s3`.
+* `STATIC_PATH` - Path to write static files to. Must be HTTP-accessible for
+  page merging to work. Required if using `local` persistence.
+* `STATIC_URI_PREFIX` - Prefix to apply to static paths (e.g.
+  http://example.org/path) to allow them to resolve. Required if using `local`
+  persistence.

--- a/lib/persisters/index.js
+++ b/lib/persisters/index.js
@@ -1,0 +1,16 @@
+"use strict";
+
+module.exports.persistTo = (path, options) => {
+  options = options || {};
+
+  switch (process.env.PERSIST) {
+  case "local":
+    return require("./local")(path);
+
+  case "s3":
+  default:
+    return require("./s3")(Object.assign({}, options, {
+      Key: path,
+    }));
+  }
+};

--- a/lib/persisters/local.js
+++ b/lib/persisters/local.js
@@ -1,0 +1,47 @@
+"use strict";
+
+const fs = require("fs"),
+  path = require("path");
+
+const env = require("require-env"),
+  mkdirp = require("mkdirp");
+
+const TARGET_PATH = env.require("STATIC_PATH"),
+  TARGET_PREFIX = env.require("STATIC_URI_PREFIX");
+
+module.exports = relativePath => {
+  const fullPath = path.join(TARGET_PATH, relativePath);
+  let prefix = TARGET_PREFIX;
+
+  if (prefix[prefix.length - 1] !== "/") {
+    prefix += "/";
+  }
+
+  return (stream, callback) => {
+    let writeStream;
+
+    mkdirp(path.dirname(fullPath), err => {
+      if (err) {
+        return callback(err);
+      }
+
+      writeStream = fs.createWriteStream(fullPath, {
+        encoding: null
+      });
+
+      writeStream.on("error", callback);
+      writeStream.on("finish", () => callback(null, `${prefix}${relativePath}`));
+
+      stream.pipe(writeStream);
+    });
+
+    return {
+      abort: () => {
+        if (writeStream) {
+          writeStream.end();
+          fs.unlink(writeStream.path);
+        }
+      }
+    };
+  };
+};

--- a/lib/persisters/s3.js
+++ b/lib/persisters/s3.js
@@ -22,7 +22,8 @@ module.exports = s3options => {
     const upload = S3.upload(options, (err, data) => {
       if (err) {
         if (err.code === "RequestAbortedError") {
-          // TODO remove the special-casing here
+          // TODO remove the special-casing here (by preventing callbacks in
+          // shell.js from being called multiple times)
           // request was aborted; an error was already raised on child exit
           return;
         }

--- a/lib/persisters/s3.js
+++ b/lib/persisters/s3.js
@@ -1,0 +1,31 @@
+"use strict";
+
+const AWS = require("aws-sdk"),
+  clone = require("clone");
+
+const S3 = new AWS.S3();
+
+module.exports = s3options => {
+  return (stream, callback) => {
+    const options = clone(s3options);
+    options.Body = stream;
+
+    const upload = S3.upload(options, (err, data) => {
+      if (err) {
+        if (err.code === "RequestAbortedError") {
+          // TODO remove the special-casing here
+          // request was aborted; an error was already raised on child exit
+          return;
+        }
+
+        return callback(err);
+      }
+
+      return callback(null, data.Location);
+    });
+
+    return {
+      abort: upload.abort
+    }
+  };
+};

--- a/lib/persisters/s3.js
+++ b/lib/persisters/s3.js
@@ -1,13 +1,22 @@
 "use strict";
 
 const AWS = require("aws-sdk"),
-  clone = require("clone");
+  env = require("require-env");
 
 const S3 = new AWS.S3();
 
+const S3_BUCKET_NAME = env.require("S3_BUCKET_NAME"),
+  S3_DEFAULT_OPTIONS = {
+    Bucket: S3_BUCKET_NAME,
+    ACL: "public-read",
+    CacheControl: "public,max-age=31536000",
+    ContentType: "application/pdf",
+  };
+
 module.exports = s3options => {
+  const options = Object.assign({}, S3_DEFAULT_OPTIONS, s3options);
+
   return (stream, callback) => {
-    const options = clone(s3options);
     options.Body = stream;
 
     const upload = S3.upload(options, (err, data) => {
@@ -26,6 +35,6 @@ module.exports = s3options => {
 
     return {
       abort: upload.abort
-    }
+    };
   };
 };

--- a/lib/shell.js
+++ b/lib/shell.js
@@ -59,6 +59,8 @@ module.exports = function shell(cmd, args, spawnOptions, persister, _callback) {
       err = new Error(util.format("Exited with %s: %s %s", code, cmd, args.join(" ")));
       err.stderr = stderr;
 
+      console.warn(err);
+
       return callback(err);
     }
   });

--- a/lib/shell.js
+++ b/lib/shell.js
@@ -3,16 +3,13 @@
 
 const util = require("util");
 
-const AWS = require("aws-sdk"),
-  clone = require("clone"),
-  _debug = require("debug");
+const _debug = require("debug");
 
 const spawn = require("./spawn");
 
-const debug = _debug("fieldpapers-tasks:shell"),
-  S3 = new AWS.S3();
+const debug = _debug("fieldpapers-tasks:shell");
 
-module.exports = function shell(cmd, args, spawnOptions, s3Options, _callback) {
+module.exports = function shell(cmd, args, spawnOptions, persister, _callback) {
   spawnOptions.encoding = "encoding" in spawnOptions ? spawnOptions.encoding : null;
   spawnOptions.env = spawnOptions.env || process.env;
   spawnOptions.killSignal = spawnOptions.killSignal || "SIGTERM";
@@ -34,22 +31,7 @@ module.exports = function shell(cmd, args, spawnOptions, s3Options, _callback) {
   // buffered (and likely surpassing execFile's maxBuffer size)
   const child = spawn(cmd, args, spawnOptions);
 
-  s3Options = clone(s3Options);
-  s3Options.Body = child.stdout;
-
-  const upload = S3.upload(s3Options, function(err, data) {
-    if (err) {
-      if (err.code === "RequestAbortedError") {
-        // request was aborted; an error was already raised on child exit
-        return;
-      }
-
-      return callback(err);
-    }
-
-    return callback(null, data.Location);
-  });
-
+  const upload = persister(child.stdout, callback);
   const _stderr = [];
 
   child.stderr.on("data", function(chunk) {

--- a/lib/tasks/convert_pdf_to_geotiff.js
+++ b/lib/tasks/convert_pdf_to_geotiff.js
@@ -5,13 +5,11 @@ const assert = require("assert"),
   fs = require("fs"),
   util = require("util");
 
-const env = require("require-env"),
-  request = require("request"),
+const request = require("request"),
   tmp = require("tmp");
 
-const spawn = require("../spawn");
-
-const S3_BUCKET_NAME = env.require("S3_BUCKET_NAME");
+const persistTo = require("../persisters").persistTo,
+  spawn = require("../spawn");
 
 const spawnAndCaptureStdErr = function spawnAndCaptureStdErr() {
   const child = spawn.apply(null, arguments);
@@ -94,13 +92,7 @@ module.exports = function convertPdfToGeoTIFF(payload, _callback) {
       timeout: 120e3
     });
 
-    let persister;
-
-    persister = s3Persister({
-      Bucket: S3_BUCKET_NAME,
-      Key: util.format("prints/%s/%s-%s.tiff", page.atlas.slug, page.atlas.slug, page.page_number),
-      ACL: "public-read",
-      CacheControl: "public,max-age=31536000",
+    const persister = persistTo(`prints/${page.atlas.slug}/${page.atlas.slug}-${page.page_number}.tiff`, {
       ContentType: "image/tiff",
     });
 

--- a/lib/tasks/convert_pdf_to_geotiff.js
+++ b/lib/tasks/convert_pdf_to_geotiff.js
@@ -5,16 +5,13 @@ const assert = require("assert"),
   fs = require("fs"),
   util = require("util");
 
-const AWS = require("aws-sdk"),
-  env = require("require-env"),
+const env = require("require-env"),
   request = require("request"),
   tmp = require("tmp");
 
 const spawn = require("../spawn");
 
 const S3_BUCKET_NAME = env.require("S3_BUCKET_NAME");
-
-const S3 = new AWS.S3();
 
 const spawnAndCaptureStdErr = function spawnAndCaptureStdErr() {
   const child = spawn.apply(null, arguments);
@@ -97,6 +94,16 @@ module.exports = function convertPdfToGeoTIFF(payload, _callback) {
       timeout: 120e3
     });
 
+    let persister;
+
+    persister = s3Persister({
+      Bucket: S3_BUCKET_NAME,
+      Key: util.format("prints/%s/%s-%s.tiff", page.atlas.slug, page.atlas.slug, page.page_number),
+      ACL: "public-read",
+      CacheControl: "public,max-age=31536000",
+      ContentType: "image/tiff",
+    });
+
     // fetch the PDF and pipe it into convert
     request
       .get(page.pdf_url)
@@ -118,22 +125,10 @@ module.exports = function convertPdfToGeoTIFF(payload, _callback) {
 
     gdalTranslate.on("exit", function(code) {
       if (code === 0) {
-        return S3.upload({
-          Bucket: S3_BUCKET_NAME,
-          Key: util.format("prints/%s/%s-%s.tiff", page.atlas.slug, page.atlas.slug, page.page_number),
-          ACL: "public-read",
-          CacheControl: "public,max-age=31536000",
-          ContentType: "image/tiff",
-          Body: fs.createReadStream(filename)
-        }, function(err, data) {
-          // remove the tmp file
+        return persister(fs.createReadStream(tiffName), (err, uri) => {
           fs.unlink(filename);
 
-          if (err) {
-            return callback(err);
-          }
-
-          return callback(null, data.Location);
+          return callback(err, uri);
         });
       }
     });

--- a/lib/tasks/merge_pages.js
+++ b/lib/tasks/merge_pages.js
@@ -2,23 +2,19 @@
 "use strict";
 
 const assert = require("assert"),
-  fs = require("fs"),
-  util = require("util");
+  fs = require("fs");
 
 const async = require("async"),
-  env = require("require-env"),
   raven = require("raven"),
   request = require("request"),
   tmp = require("tmp");
 
-const s3Persister = require("../persisters/s3"),
+const persistTo = require("../persisters").persistTo,
   shell = require("../shell");
 
 tmp.setGracefulCleanup();
 
 const sentry = new raven.Client();
-
-const S3_BUCKET_NAME = env.require("S3_BUCKET_NAME");
 
 module.exports = function mergePages(payload, _callback) {
   const atlas = payload.atlas,
@@ -28,22 +24,14 @@ module.exports = function mergePages(payload, _callback) {
       return files.forEach(function(filename) {
         fs.unlink(filename);
       });
-    };
+    },
+    persister = persistTo(`atlases/${atlas.slug}/atlas-${atlas.slug}.pdf`);
 
   let args = [
         "-q",
         "-sDEVICE=pdfwrite",
         "-o", "-"
-      ],
-      persister;
-
-  persister = s3Persister({
-    Bucket: S3_BUCKET_NAME,
-    Key: util.format("atlases/%s/atlas-%s.pdf", atlas.slug, atlas.slug),
-    ACL: "public-read",
-    CacheControl: "public,max-age=31536000",
-    ContentType: "application/pdf"
-  });
+      ];
 
   const callback = function() {
     cleanup();

--- a/lib/tasks/merge_pages.js
+++ b/lib/tasks/merge_pages.js
@@ -11,7 +11,8 @@ const async = require("async"),
   request = require("request"),
   tmp = require("tmp");
 
-const shell = require("../shell");
+const s3Persister = require("../persisters/s3"),
+  shell = require("../shell");
 
 tmp.setGracefulCleanup();
 
@@ -33,7 +34,16 @@ module.exports = function mergePages(payload, _callback) {
         "-q",
         "-sDEVICE=pdfwrite",
         "-o", "-"
-      ];
+      ],
+      persister;
+
+  persister = s3Persister({
+    Bucket: S3_BUCKET_NAME,
+    Key: util.format("atlases/%s/atlas-%s.pdf", atlas.slug, atlas.slug),
+    ACL: "public-read",
+    CacheControl: "public,max-age=31536000",
+    ContentType: "application/pdf"
+  });
 
   const callback = function() {
     cleanup();
@@ -74,13 +84,7 @@ module.exports = function mergePages(payload, _callback) {
 
     return shell(cmd, args, {
       timeout: 120e3
-    }, {
-      Bucket: S3_BUCKET_NAME,
-      Key: util.format("atlases/%s/atlas-%s.pdf", atlas.slug, atlas.slug),
-      ACL: "public-read",
-      CacheControl: "public,max-age=31536000",
-      ContentType: "application/pdf"
-    }, function(err, uri) {
+    }, persister, function(err, uri) {
       const responsePayload = {
         task: payload.task,
         atlas: {

--- a/lib/tasks/process_snapshot.js
+++ b/lib/tasks/process_snapshot.js
@@ -13,7 +13,8 @@ const async = require("async"),
   request = require("request"),
   tmp = require("tmp");
 
-const spawn = require("../spawn");
+const s3Persister = require("../persisters/s3"),
+  spawn = require("../spawn");
 
 const sentry = new raven.Client();
 
@@ -73,6 +74,16 @@ module.exports = function processSnapshot(payload, callback) {
     const filename = filenames.source,
       tiffName = filenames.tiff;
 
+    let persister;
+
+    persister = s3Persister({
+      Bucket: S3_BUCKET_NAME,
+      Key: util.format("snapshots/%s/field-paper-%s.tiff", snapshot.slug, snapshot.slug),
+      ACL: "public-read",
+      CacheControl: "public,max-age=31536000",
+      ContentType: "image/tiff",
+    });
+
     return async.waterfall([
       async.apply(download, snapshot.image_url, filename),
       function(done) {
@@ -99,20 +110,8 @@ module.exports = function processSnapshot(payload, callback) {
         child.stdout.pipe(fs.createWriteStream(tiffName));
       },
       function(done) {
-        return S3.upload({
-          Bucket: S3_BUCKET_NAME,
-          Key: util.format("snapshots/%s/field-paper-%s.tiff", snapshot.slug, snapshot.slug),
-          ACL: "public-read",
-          CacheControl: "public,max-age=31536000",
-          ContentType: "image/tiff",
-          Body: fs.createReadStream(tiffName)
-        }, function(err, data) {
-          if (err) {
-            return done(err);
-          }
-
-          return done(null, decodeURIComponent(data.Location));
-        });
+        // TODO this used to decodeURIComponent(data.Location), but that doesn't occur elsewhere
+        return persister(fs.createReadStream(tiffName), done);
       }
     ], function(err, geoTiffUrl) {
       // remove the tmp files

--- a/lib/tasks/process_snapshot.js
+++ b/lib/tasks/process_snapshot.js
@@ -8,17 +8,14 @@ const assert = require("assert"),
 
 const async = require("async"),
   AWS = require("aws-sdk"),
-  env = require("require-env"),
   raven = require("raven"),
   request = require("request"),
   tmp = require("tmp");
 
-const s3Persister = require("../persisters/s3"),
+const persistTo = require("../persisters").persistTo,
   spawn = require("../spawn");
 
 const sentry = new raven.Client();
-
-const S3_BUCKET_NAME = env.require("S3_BUCKET_NAME");
 
 const S3 = new AWS.S3();
 
@@ -72,17 +69,10 @@ module.exports = function processSnapshot(payload, callback) {
     }
 
     const filename = filenames.source,
-      tiffName = filenames.tiff;
-
-    let persister;
-
-    persister = s3Persister({
-      Bucket: S3_BUCKET_NAME,
-      Key: util.format("snapshots/%s/field-paper-%s.tiff", snapshot.slug, snapshot.slug),
-      ACL: "public-read",
-      CacheControl: "public,max-age=31536000",
-      ContentType: "image/tiff",
-    });
+      tiffName = filenames.tiff,
+      persister = persistTo(`snapshots/${snapshot.slug}/field-paper-${snapshot.slug}.tiff`, {
+        ContentType: "image/tiff",
+      });
 
     return async.waterfall([
       async.apply(download, snapshot.image_url, filename),

--- a/lib/tasks/render_index.js
+++ b/lib/tasks/render_index.js
@@ -1,21 +1,18 @@
 /* eslint camelcase:0 */
 "use strict";
 
-const assert = require("assert"),
-  util = require("util");
+const assert = require("assert");
 
 const clone = require("clone"),
-  env = require("require-env"),
   raven = require("raven");
 
-const s3Persister = require("../persisters/s3"),
+const persistTo = require("../persisters").persistTo,
   shell = require("../shell");
 
 const sentry = new raven.Client();
 
 const API_BASE_URL = process.env.API_BASE_URL || "http://fieldpapers.org/",
-  ENV = clone(process.env),
-  S3_BUCKET_NAME = env.require("S3_BUCKET_NAME");
+  ENV = clone(process.env);
 
 ENV.API_BASE_URL = API_BASE_URL;
 
@@ -37,17 +34,8 @@ module.exports = function renderIndex(payload, callback) {
       "-r", page.atlas.rows,
       "-t", page.atlas.text,
       page.atlas.slug
-    ];
-
-  let persister;
-
-  persister = s3Persister({
-    Bucket: S3_BUCKET_NAME,
-    Key: util.format("atlases/%s/atlas-%s.pdf", page.atlas.slug, page.atlas.slug),
-    ACL: "public-read",
-    CacheControl: "public,max-age=31536000",
-    ContentType: "application/pdf"
-  });
+    ],
+    persister = persistTo(`atlases/${page.atlas.slug}/${page.atlas.slug}-index.pdf`);
 
   return shell(cmd, args, {
     cwd: "/opt/paper",

--- a/lib/tasks/render_index.js
+++ b/lib/tasks/render_index.js
@@ -8,7 +8,8 @@ const clone = require("clone"),
   env = require("require-env"),
   raven = require("raven");
 
-const shell = require("../shell");
+const s3Persister = require("../persisters/s3"),
+  shell = require("../shell");
 
 const sentry = new raven.Client();
 
@@ -38,18 +39,22 @@ module.exports = function renderIndex(payload, callback) {
       page.atlas.slug
     ];
 
-  return shell(cmd, args, {
-    cwd: "/opt/paper",
-    env: ENV,
-    killSignal: "SIGKILL",
-    timeout: 120e3
-  }, {
+  let persister;
+
+  persister = s3Persister({
     Bucket: S3_BUCKET_NAME,
     Key: util.format("atlases/%s/atlas-%s.pdf", page.atlas.slug, page.atlas.slug),
     ACL: "public-read",
     CacheControl: "public,max-age=31536000",
     ContentType: "application/pdf"
-  }, function(err, uri) {
+  });
+
+  return shell(cmd, args, {
+    cwd: "/opt/paper",
+    env: ENV,
+    killSignal: "SIGKILL",
+    timeout: 120e3
+  }, persister, function(err, uri) {
     const responsePayload = {
       task: payload.task,
       page: {

--- a/lib/tasks/render_page.js
+++ b/lib/tasks/render_page.js
@@ -1,21 +1,18 @@
 /* eslint camelcase:0 */
 "use strict";
 
-const assert = require("assert"),
-  util = require("util");
+const assert = require("assert");
 
 const clone = require("clone"),
-  env = require("require-env"),
   raven = require("raven");
 
-const s3Persister = require("../persisters/s3"),
+const persistTo = require("../persisters").persistTo,
   shell = require("../shell");
 
 const sentry = new raven.Client();
 
 const API_BASE_URL = process.env.API_BASE_URL || "http://fieldpapers.org/",
-  ENV = clone(process.env),
-  S3_BUCKET_NAME = env.require("S3_BUCKET_NAME");
+  ENV = clone(process.env);
 
 ENV.API_BASE_URL = API_BASE_URL;
 
@@ -35,17 +32,8 @@ module.exports = function renderPage(payload, callback) {
       }).replace("@2x", "").replace(/,$/, ""),
       "-t", page.atlas.text,
       page.atlas.slug
-    ];
-
-  let persister;
-
-  persister = s3Persister({
-    Bucket: S3_BUCKET_NAME,
-    Key: util.format("atlases/%s/%s-%s.pdf", page.atlas.slug, page.atlas.slug, page.page_number),
-    ACL: "public-read",
-    CacheControl: "public,max-age=31536000",
-    ContentType: "application/pdf"
-  });
+    ],
+    persister = persistTo(`atlases/${page.atlas.slug}/${page.atlas.slug}-${page.page_number}.pdf`);
 
   return shell(cmd, args, {
     cwd: "/opt/paper",

--- a/lib/tasks/render_page.js
+++ b/lib/tasks/render_page.js
@@ -8,7 +8,8 @@ const clone = require("clone"),
   env = require("require-env"),
   raven = require("raven");
 
-const shell = require("../shell");
+const s3Persister = require("../persisters/s3"),
+  shell = require("../shell");
 
 const sentry = new raven.Client();
 
@@ -36,18 +37,22 @@ module.exports = function renderPage(payload, callback) {
       page.atlas.slug
     ];
 
-  return shell(cmd, args, {
-    cwd: "/opt/paper",
-    env: ENV,
-    killSignal: "SIGKILL",
-    timeout: 120e3
-  }, {
+  let persister;
+
+  persister = s3Persister({
     Bucket: S3_BUCKET_NAME,
     Key: util.format("atlases/%s/%s-%s.pdf", page.atlas.slug, page.atlas.slug, page.page_number),
     ACL: "public-read",
     CacheControl: "public,max-age=31536000",
     ContentType: "application/pdf"
-  }, function(err, uri) {
+  });
+
+  return shell(cmd, args, {
+    cwd: "/opt/paper",
+    env: ENV,
+    killSignal: "SIGKILL",
+    timeout: 120e3
+  }, persister, function(err, uri) {
     const responsePayload = {
       task: payload.task,
       page: {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "debug": "^2.2.0",
     "express": "^4.12.3",
     "holdtime": "^0.1.1",
+    "mkdirp": "^0.5.1",
     "morgan": "^1.5.3",
     "raven": "^0.7.3",
     "request": "^2.55.0",


### PR DESCRIPTION
Refactors file persistence to support both S3 and local using `PERSIST={local,s3}`. Relevant local persistence environment vars: `STATIC_PATH`, `STATIC_URI_PREFIX`.

/cc @jflemer-ndp
